### PR TITLE
Fix header Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently the output is NTSC or PAL at a resolution of 128x96 by default. The li
 
 There are some timing issues with the m1284p, may be related to sanguino core.
 
-##Connections
+## Connections
 
 MCU | SYNCOUT | AUDIOOUT | VIDEO | VSYNCIN | CSYNCIN
 ---|---|---|---|---|---
@@ -34,7 +34,7 @@ On NG, Decimila, UNO and Nano the SYNCOUT is pin 9, video on 7 and AUDIOOUT on 1
 On Mega2560	SYNCOUT is pin 11, video is on A7(D29) and AUDIOOUT is on pin 10.
 
 
-##Examples
+## Examples
 
 https://youtu.be/MEg_V4YZDh0
 


### PR DESCRIPTION
GitHub's Markdown interpreter was recently changed to strictly enforce the [GFM spec](https://github.github.com/gfm/), which requires a delimiting space in header Markdown. This has caused some Markdown to no longer display as originally intended.

More information:
https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown
https://github.com/github/markup/issues/1013